### PR TITLE
Update correct branch of kernel-techpack-data-kernel

### DIFF
--- a/aosp.dependencies
+++ b/aosp.dependencies
@@ -21,7 +21,7 @@
     "remote":       "github",
     "repository":   "sonyxperiadev/kernel-techpack-data-kernel",
     "target_path":  "kernel/sony/msm-4.14/kernel/techpack/data-kernel",
-    "branch":     "LA.UM.7.1.r1"
+    "branch":     "aosp/LA.UM.7.1.r1"
   },
   {
     "remote":       "github",


### PR DESCRIPTION
Now that the branch has been renamed to follow the naming standard
we need to use the correct one.