### PR TITLE
correct xperia apollo identification for the bootanimation

### DIFF
--- a/customization.mk
+++ b/customization.mk
@@ -28,7 +28,7 @@ TARGET_SCREEN_HEIGHT := 1920
 TARGET_SCREEN_WIDTH := 1080
 endif
 
-ifneq ($(filter aosp_h82%6 aosp_83%4, $(TARGET_PRODUCT)),)
+ifneq ($(filter aosp_h82%6 aosp_h83%4, $(TARGET_PRODUCT)),)
 TARGET_SCREEN_HEIGHT := 2160
 TARGET_SCREEN_WIDTH := 1080
 endif


### PR DESCRIPTION
The filter was wrong, it missed a "h" in the TARGET_PRODUCT value

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pixelexperience-devices/device_sony_customization/2)
<!-- Reviewable:end -->
