### PR TITLE
aosp.dependencies: Add media repo for legacy devices

### DIFF
--- a/aosp.dependencies
+++ b/aosp.dependencies
@@ -258,6 +258,12 @@
   },
   {
     "remote":       "github",
+    "repository":   "sonyxperiadev/hardware-qcom-media",
+    "target_path":  "hardware/qcom/media/sdm660-libion",
+    "branch":     "aosp/LA.UM.8.2.1.r1"
+  },
+  {
+    "remote":       "github",
     "repository":   "sonyxperiadev/camera",
     "target_path":  "vendor/qcom/opensource/camera",
     "branch":     "aosp/LA.UM.6.4.r1"


### PR DESCRIPTION
We switched legacy SoCs in range of msm8956 to sdm660 to new location.
So follow this change also here.