### PR TITLE
customization.mk: Remove now duplicated prop media.stagefright.thumbnail.prefer_hw_codecs=true

### DIFF
--- a/customization.mk
+++ b/customization.mk
@@ -84,9 +84,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.secure=0 \
     ro.debuggable=1
 
-PRODUCT_PROPERTY_OVERRIDES += \
-        media.stagefright.thumbnail.prefer_hw_codecs=true
-
 # Update recovery with the ota for legacy
 ifneq ($(filter loire tone yoshino, $(SOMC_PLATFORM)),)
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
PRODUCT_PROPERTY_OVERRIDES += \
        media.stagefright.thumbnail.prefer_hw_codecs=true

is already defined in https://github.com/sonyxperiadev/device-sony-common/blob/9ebcd145f2b4dda80dde7dbb2bca4457bf4764c5/common-prop.mk#L87

Signed-off-by: Martin Dünkelmann <nc-duenkekl3@netcologne.de>