### PR TITLE
aosp.dependencies : set a defined branch for ipacfg

### DIFF
--- a/aosp.dependencies
+++ b/aosp.dependencies
@@ -300,7 +300,8 @@
   },
   {
     "repository":   "device_sony_ipacfg-mgr",
-    "target_path":  "hardware/qcom/data/ipacfg-mgr/sdm845"
+    "target_path":  "hardware/qcom/data/ipacfg-mgr/sdm845",
+    "branch":     "ten"
   },
   {
     "remote":       "github",


### PR DESCRIPTION
This is needed for pe-plus hence ipa have only ten branch and it's not useful to make a ten-plus just for that