### PR TITLE
ims/cne/sepolicy/cnd.te: Fix double declaration error

### DIFF
--- a/ims/cne/sepolicy/cnd.te
+++ b/ims/cne/sepolicy/cnd.te
@@ -1,8 +1,0 @@
-#permissive cnd;
-type cnd, domain;
-type cnd_exec, exec_type, vendor_file_type, file_type;
-
-#file_type_auto_trans(cnd, socket_device, cnd_socket);
-
-# cnd is started by init, type transit from init domain to cnd domain
-init_daemon_domain(cnd)


### PR DESCRIPTION
The policy file got added in SODP with commit

https://github.com/sonyxperiadev/device-sony-sepolicy/commit/92765561bf1882a33bea977e08baa128317ed57f