### PR TITLE
aosp.dependencies: Switch sony-sepolicy to q-mr1 branch

### DIFF
--- a/aosp.dependencies
+++ b/aosp.dependencies
@@ -51,7 +51,7 @@
     "remote":       "github",
     "repository":   "sonyxperiadev/device-sony-sepolicy",
     "target_path":  "device/sony/sepolicy",
-    "branch":     "master"
+    "branch":     "q-mr1"
   },
   {
     "remote":       "github",


### PR DESCRIPTION
Master branch is used for future development and for the current code we should stick to q-mr1 branch.