### PR TITLE
Customization.mk: Remove the 'Temporary: CnE' code

### DIFF
--- a/Customization.mk
+++ b/Customization.mk
@@ -33,7 +33,3 @@ TARGET_COMPILE_WITH_MSM_KERNEL := true
 TARGET_KERNEL_SOURCE := kernel/sony/msm-4.14/kernel
 TARGET_NEEDS_DTBOIMAGE := false
 
-# Temporary: CnE
-DEVICE_MANIFEST_FILE += $(CUST_PATH)/ims/cne/vendor.hw.cneservices.xml
-
-BOARD_VENDOR_SEPOLICY_DIRS += $(CUST_PATH)/ims/cne/sepolicy


### PR DESCRIPTION
Fixes a build error after moving the IMS/CnE stuff to SODP

See https://github.com/sonyxperiadev/device-sony-common/pull/770 for reference