### PR TITLE
[TEN] customization.mk: Define PDX201 screen resolution.

### DIFF
--- a/customization.mk
+++ b/customization.mk
@@ -27,7 +27,7 @@ TARGET_SCREEN_HEIGHT := 1280
 TARGET_SCREEN_WIDTH := 720
 endif
 
-ifneq ($(filter aosp_f51% aosp_f8% aosp_g82% aosp_g83% aosp_h%13 aosp_i%13, $(TARGET_PRODUCT)),)
+ifneq ($(filter aosp_f51% aosp_f8% aosp_g82% aosp_g83% aosp_h%13 aosp_i%13 aosp_xqau%, $(TARGET_PRODUCT)),)
 TARGET_SCREEN_HEIGHT := 1920
 TARGET_SCREEN_WIDTH := 1080
 endif


### PR DESCRIPTION
PDX201 resolution for boot animation was left undefined by accident and we would get nice warning.
I'm weird and i hate warnings so lets define the resolution to 1080p.