### PR TITLE
Update the link for NXP NFC firmware

### DIFF
--- a/aosp.dependencies
+++ b/aosp.dependencies
@@ -190,7 +190,7 @@
   },
   {
     "remote":       "github",
-    "repository":   "NXPNFCProject/NXPNFCC_FW",
+    "repository":   "NXP/nfc-NXPNFCC_FW",
     "target_path":  "vendor/nxp/NXPNFCC_FW",
     "branch":     "master"
   },


### PR DESCRIPTION
This change was done in response to https://github.com/sonyxperiadev/local_manifests/commit/5062f3cec6165112a740cbf0f753e7578b8e6dab.

@Paulbouchara Please CP it to ten-plus also. Didnt want to open 2 PRs