### PR TITLE
Disable 4.19 kernel for now & update to correct repo branches

### DIFF
--- a/aosp.dependencies
+++ b/aosp.dependencies
@@ -49,66 +49,6 @@
   },
   {
     "remote":       "github",
-    "repository":   "sonyxperiadev/device-sony-common-headers",
-    "target_path":  "kernel/sony/msm-4.19/common-headers",
-    "branch":     "aosp/LA.UM.9.12.r1"
-  },
-  {
-    "remote":       "github",
-    "repository":   "sonyxperiadev/kernel",
-    "target_path":  "kernel/sony/msm-4.19/kernel",
-    "branch":     "aosp/LA.UM.9.12.r1"
-  },
-  {
-    "remote":       "github",
-    "repository":   "sonyxperiadev/kernel-techpack-audio",
-    "target_path":  "kernel/sony/msm-4.19/kernel/techpack/audio",
-    "branch":     "aosp/LA.UM.9.12.r1"
-  },
-  {
-    "remote":       "github",
-    "repository":   "sonyxperiadev/kernel-techpack-camera",
-    "target_path":  "kernel/sony/msm-4.19/kernel/techpack/camera",
-    "branch":     "aosp/LA.UM.9.12.r1"
-  },
-  {
-    "remote":       "github",
-    "repository":   "sonyxperiadev/kernel-techpack-data-kernel",
-    "target_path":  "kernel/sony/msm-4.19/kernel/techpack/data-kernel",
-    "branch":     "aosp/LA.UM.9.12.r1"
-  },
-  {
-    "remote":       "github",
-    "repository":   "sonyxperiadev/kernel-techpack-display-driver",
-    "target_path":  "kernel/sony/msm-4.19/kernel/techpack/display",
-    "branch":     "aosp/LA.UM.9.12.r1"
-  },
-  {
-    "remote":       "github",
-    "repository":   "sonyxperiadev/kernel-defconfig",
-    "target_path":  "kernel/sony/msm-4.19/kernel/arch/arm64/configs/sony",
-    "branch":     "aosp/LA.UM.9.12.r1"
-  },
-  {
-    "remote":       "github",
-    "repository":   "sonyxperiadev/vendor-qcom-opensource-wlan-fw-api",
-    "target_path":  "kernel/sony/msm-4.19/kernel/drivers/staging/wlan-qc/fw-api",
-    "branch":     "aosp/LA.UM.9.12.r1"
-  },
-  {
-    "remote":       "github",
-    "repository":   "sonyxperiadev/vendor-qcom-opensource-wlan-qca-wifi-host-cmn",
-    "target_path":  "kernel/sony/msm-4.19/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn",
-    "branch":     "aosp/LA.UM.9.12.r1"
-  },
-  {
-    "remote":       "github",
-    "repository":   "sonyxperiadev/vendor-qcom-opensource-wlan-qcacld-3.0",
-    "target_path":  "kernel/sony/msm-4.19/kernel/drivers/staging/wlan-qc/qcacld-3.0",
-    "branch":     "aosp/LA.UM.9.12.r1"
-  },
-  {
-    "remote":       "github",
     "repository":   "sonyxperiadev/device-sony-sepolicy",
     "target_path":  "device/sony/sepolicy",
     "branch":     "master"

--- a/aosp.dependencies
+++ b/aosp.dependencies
@@ -284,7 +284,7 @@
     "remote":       "github",
     "repository":   "sonyxperiadev/hardware-qcom-display",
     "target_path":  "vendor/qcom/opensource/display",
-    "branch":     "aosp/LA.UM.9.12.r1"
+    "branch":     "aosp/LA.UM.8.1.r1"
   },
   {
     "remote":       "github",
@@ -296,6 +296,12 @@
     "remote":       "github",
     "repository":   "sonyxperiadev/hardware-qcom-media-sm8150",
     "target_path":  "vendor/qcom/opensource/media/sm8150",
+    "branch":     "aosp/LA.UM.8.1.r1"
+  },
+  {
+    "remote":       "github",
+    "repository":   "sonyxperiadev/hardware-qcom-media-sm8150",
+    "target_path":  "vendor/qcom/opensource/media/sm8250",
     "branch":     "aosp/LA.UM.9.12.r1"
   },
   {
@@ -355,7 +361,7 @@
     "remote":       "github",
     "repository":   "sonyxperiadev/vendor-qcom-opensource-commonsys-intf-display",
     "target_path":  "vendor/qcom/opensource/display-commonsys-intf",
-    "branch":     "aosp/LA.UM.9.12.r1"
+    "branch":     "aosp/LA.UM.8.1.r1"
   },
   {
     "remote":       "github",


### PR DESCRIPTION
Disabling of 4.19 kernel was needed because of conflicting kernel headers from 4.14.
Until this issue is resolved and pushed lets remove the kernel as to not break building for people.

Branches were updated using the master local manifest of SODP which isnt meant for all devices
but only as Edo testing ground basically. Update them using r32 local manifest.