### PR TITLE
aosp.dependencies: Change sony-common branch to r-mr1

### DIFF
--- a/aosp.dependencies
+++ b/aosp.dependencies
@@ -57,7 +57,7 @@
     "remote":       "github",
     "repository":   "sonyxperiadev/device-sony-common",
     "target_path":  "device/sony/common",
-    "branch":     "master"
+    "branch":     "r-mr1"
   },
   {
     "remote":       "github",


### PR DESCRIPTION
device-sony-common master branch now has some WIP for bringing up Edo support that for now breaks
every other device due to HAL imcompatibility.
r-mr1 branch on the other hands is for Android R but doesnt have those changes.
Switch the branch from master to r-mr1 to fix build.

error: https://pastebin.com/H2vXtMjb