### PR TITLE
aosp.dependencies: Add qti-headers repo

### DIFF
--- a/aosp.dependencies
+++ b/aosp.dependencies
@@ -7,6 +7,12 @@
   },
   {
     "remote":       "github",
+    "repository":   "sonyxperiadev/qti-headers",
+    "target_path":  "kernel/sony/qti-headers",
+    "branch":     "master"
+  },
+  {
+    "remote":       "github",
     "repository":   "sonyxperiadev/kernel",
     "target_path":  "kernel/sony/msm-4.14/kernel",
     "branch":     "aosp/LA.UM.7.1.r1"


### PR DESCRIPTION
This is the workaround repo for headers issue on SODP.
Pull it in while syncing to fix the issue on PE as well :)