### PR TITLE
[eleven] customization: Fix ims lib bindmount path

### DIFF
--- a/customization.mk
+++ b/customization.mk
@@ -148,7 +148,7 @@ PRODUCT_COPY_FILES += \
 
 # Create folder to bindmount libs for the IMS VideoTelephony
 PRODUCT_COPY_FILES += \
-    $(CUST_PATH)/ims/emptyfile:$(TARGET_COPY_OUT_PRODUCT)/priv-app/ims/lib/arm64/bind_mount_lib64_here
+    $(CUST_PATH)/ims/emptyfile:$(TARGET_COPY_OUT_SYSTEM_EXT)/priv-app/ims/lib/arm64/bind_mount_lib64_here
 
 # USB debugging at boot
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/ims/bindmountims.rc
+++ b/ims/bindmountims.rc
@@ -2,4 +2,4 @@ on post-fs
     # ims.apk relies on libimscamera_jni and libimsmedia_jni.
     # For more information about this specific bindmount, please
     # check the readme in common-binds.mk
-    mount none /odm/lib64 /product/priv-app/ims/lib/arm64 bind rec
+    mount none /odm/lib64 /system/system_ext/priv-app/ims/lib/arm64 bind rec


### PR DESCRIPTION
IMS was already in /system_ext, so fix the path.