### PR TITLE
aosp.dependencies: Seperate display HALs.

### DIFF
--- a/aosp.dependencies
+++ b/aosp.dependencies
@@ -349,8 +349,14 @@
   {
     "remote":       "github",
     "repository":   "sonyxperiadev/hardware-qcom-display",
-    "target_path":  "vendor/qcom/opensource/display",
-    "branch":     "aosp/LA.UM.8.1.r1"
+    "target_path":  "vendor/qcom/opensource/display/sm8150",
+    "branch":     "aosp/LA.UM.8.1.r1_r-mr1"
+  },
+  {
+    "remote":       "github",
+    "repository":   "sonyxperiadev/hardware-qcom-display",
+    "target_path":  "vendor/qcom/opensource/display/sm8250",
+    "branch":     "aosp/LA.UM.9.12.r1"
   },
   {
     "remote":       "github",
@@ -426,8 +432,14 @@
   {
     "remote":       "github",
     "repository":   "sonyxperiadev/vendor-qcom-opensource-commonsys-intf-display",
-    "target_path":  "vendor/qcom/opensource/display-commonsys-intf",
-    "branch":     "aosp/LA.UM.8.1.r1"
+    "target_path":  "vendor/qcom/opensource/display-commonsys-intf/sm8150",
+    "branch":     "aosp/LA.UM.8.1.r1_r-mr1"
+  },
+  {
+    "remote":       "github",
+    "repository":   "sonyxperiadev/vendor-qcom-opensource-commonsys-intf-display",
+    "target_path":  "vendor/qcom/opensource/display-commonsys-intf/sm8250",
+    "branch":     "aosp/LA.UM.9.12.r1"
   },
   {
     "remote":       "github",


### PR DESCRIPTION
This changes is needed since upstream (SODP local manifest)
we switched to having 2 display HALs in the same tree.